### PR TITLE
Fix missing boolean columns in alert_notification

### DIFF
--- a/pkg/postgresql/import.go
+++ b/pkg/postgresql/import.go
@@ -75,6 +75,10 @@ func (db *DB) prepareTables() error {
 	changes := `ALTER TABLE alert ALTER COLUMN silenced TYPE integer USING silenced::integer;
 	ALTER TABLE alert_notification ALTER COLUMN is_default DROP DEFAULT;
 	ALTER TABLE alert_notification ALTER COLUMN is_default TYPE integer USING is_default::integer;
+	ALTER TABLE alert_notification ALTER COLUMN send_reminder DROP DEFAULT;
+	ALTER TABLE alert_notification ALTER COLUMN send_reminder TYPE integer USING send_reminder::integer;
+	ALTER TABLE alert_notification ALTER COLUMN disable_resolve_message DROP DEFAULT;
+	ALTER TABLE alert_notification ALTER COLUMN disable_resolve_message TYPE integer USING disable_resolve_message::integer;
 	ALTER TABLE dashboard ALTER COLUMN is_folder DROP DEFAULT;
 	ALTER TABLE dashboard ALTER COLUMN is_folder TYPE integer USING is_folder::integer;
 	ALTER TABLE dashboard ALTER COLUMN has_acl DROP DEFAULT;
@@ -117,6 +121,18 @@ func (db *DB) decodeBooleanColumns() error {
 			ALTER COLUMN is_default TYPE boolean
 			USING CASE WHEN is_default = 0 THEN FALSE
 				WHEN is_default = 1 THEN TRUE
+				ELSE NULL
+				END;
+		ALTER TABLE alert_notification
+			ALTER COLUMN send_reminder TYPE boolean
+			USING CASE WHEN send_reminder = 0 THEN FALSE
+				WHEN send_reminder = 1 THEN TRUE
+				ELSE NULL
+				END;
+		ALTER TABLE alert_notification
+			ALTER COLUMN disable_resolve_message TYPE boolean
+			USING CASE WHEN disable_resolve_message = 0 THEN FALSE
+				WHEN disable_resolve_message = 1 THEN TRUE
 				ELSE NULL
 				END;
 		ALTER TABLE alert_notification ALTER COLUMN is_default SET DEFAULT false;


### PR DESCRIPTION
Fix for missing boolean columns in alert_notification table (Grafana 6.2.4)

`FATAL[2019-08-12T19:36:13Z] ❌ pq: column "send_reminder" is of type boolean but expression is of type integer INSERT INTO "alert_notification" VALUES(...); - failed to import dump file to Postgres.`

and

FATAL[2019-08-12T20:22:23Z] ❌ pq: column "disable_resolve_message" is of type boolean but expression is of type integer INSERT INTO "alert_notification" VALUES(...); - failed to import dump file to Postgres.