### PR TITLE
feat: Added support for Grafana 8

### DIFF
--- a/pkg/postgresql/tablechanges.go
+++ b/pkg/postgresql/tablechanges.go
@@ -25,6 +25,15 @@ var TableChanges = []TableChange{
 		},
 	},
 	{
+		Table: "alert_configuration",
+		Columns: []Column{
+		    {
+		        Name: "\"default\"",
+		        Default: "false",
+		    },
+		},
+	},
+	{
 		Table: "alert_notification",
 		Columns: []Column{
 			{
@@ -128,6 +137,10 @@ var TableChanges = []TableChange{
 				Name:    "is_disabled",
 				Default: "false",
 			},
+            {
+                Name:    "is_service_account",
+                Default: "false",
+            },
 		},
 	},
 	{


### PR DESCRIPTION
Added two new columns to  `TableChanges`:

Table `alert_configuration` needed `default` column mapped as boolean.
Added new column `is_service_account` to `user` table.

I performed a migration from Grafana 8 and it looks like everything is working properly.