### PR TITLE
Dockerfile: compile the latest sqlite3 from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,12 @@ RUN make
 FROM golang:1.15
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/wbh1/grafana-sqlite-to-postgres/dist/grafana-migrate_linux* ./grafana-migrate
-RUN apt-get update && apt-get install -y \
-    sqlite3 \
- && rm -rf /var/lib/apt/lists/*
+RUN mkdir /tmp/sqlite3 \
+    && cd /tmp/sqlite3/ \
+    && curl -sSfL https://www.sqlite.org/2022/sqlite-autoconf-3390200.tar.gz | tar zxv --strip-components 1 \
+    && ./configure \
+    && make -j \
+    && make install \
+    && cd ~ \
+    && rm -rf /tmp/sqlite3
 ENTRYPOINT ["./grafana-migrate"]


### PR DESCRIPTION
the latest sqlite3 binary supports UFT-8 better which makes it indirectly solve #19