### PR TITLE
Add is_revoked for api key table

### DIFF
--- a/pkg/postgresql/tablechanges.go
+++ b/pkg/postgresql/tablechanges.go
@@ -172,4 +172,13 @@ var TableChanges = []TableChange{
 			},
 		},
 	},
+	{
+		Table: "api_key",
+		Columns: []Column{
+			{
+				Name:    "is_revoked",
+				Default: "false",
+			},
+		},
+	},
 }


### PR DESCRIPTION
In grafana 9.2.4 I stumbled to error like

pq: column "is_revoked" is of type boolean but expression is of type integer INSERT INTO "api_key" VALUES(1,1,'argocd','721b6988520348318be28ff74596c450f980f1fe44eec295168bc8439821a751c202e93bbd885aa94d3ade39ce23267369f7','Editor','2022-09-03 13:26:12','2022-09-03 13:26:12',1977571572,NULL,'2022-11-03 09:44:32',0) - failed to import dump file to Postgres.

that pr fix this.