### PR TITLE
Add more columns that require transforming sqlite integer -> postgres boolean

### DIFF
--- a/pkg/postgresql/tablechanges.go
+++ b/pkg/postgresql/tablechanges.go
@@ -34,6 +34,33 @@ var TableChanges = []TableChange{
 		},
 	},
 	{
+		Table: "alert_configuration_history",
+		Columns: []Column{
+			{
+				Name:    "\"default\"",
+				Default: "false",
+			},
+		},
+	},
+	{
+		Table: "alert_rule",
+		Columns: []Column{
+			{
+				Name:    "is_paused",
+				Default: "false",
+			},
+		},
+	},
+	{
+		Table: "alert_rule_version",
+		Columns: []Column{
+			{
+				Name:    "is_paused",
+				Default: "false",
+			},
+		},
+	},
+	{
 		Table: "alert_notification",
 		Columns: []Column{
 			{


### PR DESCRIPTION
This is similar to https://github.com/wbh1/grafana-sqlite-to-postgres/pull/24 but adds more columns which broke for me.

I have tested this PR and it works for me for Grafana 9.4.3, SQLite 3.37.2, PostgreSQL 14.5  

The following `table.colum`  are affected:
```
alert_configuration_history.default
alert_rule.is_paused
alert_rule_version.is_paused
```

These are the errors I encountered before:
```
FATAL[2023-03-15T05:44:16Z] ❌ pq: column "default" is of type boolean but expression is of type integer INSERT INTO "alert_configuration_history" VALUES(1,1,replace('{\n      "alertmanager_config": {\n           "route": {\n                    "receiver": "grafana-default-email",\n                  "group_by": ["grafana_folder", "alertname"]\n           },\n            "receivers": [{\n                    "name": "grafana-default-email",\n                      "grafana_managed_receiver_configs": [{\n                                "uid": "",\n                "name": "email receiver",\n                              "type": "email",\n                              "isDefault": true,\n                            "settings": {\n                     "addresses": "<example@email.com>"\n                             }\n                     }]\n            }]\n    }\n}\n','\n',chr(10)),'e0528a75784033ae7b15c40851d89484','v1',1678455492,1) - failed to import dump file to Postgres. 
```

and
```
FATAL[2023-03-15T05:08:00Z] ❌ pq: column "is_paused" is of type boolean but expression is of type integer INSERT INTO "alert_rule" VALUES(1,1,'XXXXX','A','[{"refId":"A","queryType":"","relativeTimeRange":{"from":3600,"to":0},"datasourceUid":"pg_advisor","model":{"datasource":{"type":"postgres","uid":"pg_advisor"},"editorMode":"code","format":"table","group":[],"intervalMs":60000,"maxDataPoints":43200,"metricColumn":"none","rawQuery":true,"rawSql":"with dd as (\nSELECT o.id, o.str_code, o.name, m.str_code as model_str, m.id as modelid\n\t\tFROM pp_object_object o\n\t\tJOIN pp_object_objectmodel m ON o.object_model_id = m.id\n\t\tWHERE m.enterprise_id in (select id from pp_org_enterprise where str_code = ''bystr'')\n\t\tAND o.str_code in (''401'',''404'',''405'',''406'',''407'',''408'',''409'',''410'',''411'',''412'')\n),\nts as (\nselect *\nfrom public.pp_ts_sensorarchive\nwhere $__timeFilter(time)\n)\n\nselect str_code as object, case when perc_data \u003e 0.9 THEN 0 ELSE 1 END \n\tfrom (\n\tselect dd.str_code, count(ts.time)/(3600.0) as perc_data\n\tfrom ts\n\tjoin (SELECT id, tag FROM pp_object_sensor\n\t\t  where tag in (''main_power'')) ss\n\ton ts.sensor_id = ss.id\n\tright join dd on dd.id = ts.object_id\n\tgroup by dd.str_code\n) gr","refId":"A","select":[[{"params":["lat"],"type":"column"}]],"sql":{"columns":[{"parameters":[],"type":"function"}],"groupBy":[{"property":{"type":"string"},"type":"groupBy"}],"limit":50},"table":"pp_ts_sensorarchive","timeColumn":"start_at","timeColumnType":"timestamp","where":[]}}]','2023-03-14 09:46:03',3600,92,'CLFXXXX','sPjXXXXX','bystr','NoData','OK',3600000000000,'{"__dashboardUid__":"R5XXX","__panelId__":"2"}','{"level":"0"}','R5XXXXX',2,1,0) - failed to import dump file to Postgres. 
```


In sqlite3 these columns are INTEGER DEFAULT 0:
```
sqlite> .schema alert_configuration_history 
CREATE TABLE `alert_configuration_history` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `org_id` INTEGER NOT NULL DEFAULT 0
, `alertmanager_configuration` TEXT NOT NULL
, `configuration_hash` TEXT NOT NULL DEFAULT 'not-yet-calculated'
, `configuration_version` TEXT NOT NULL
, `created_at` INTEGER NOT NULL
, `default` INTEGER NOT NULL DEFAULT 0
);
sqlite> .schema alert_rule
CREATE TABLE `alert_rule` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `org_id` INTEGER NOT NULL
, `title` TEXT NOT NULL
, `condition` TEXT NOT NULL
, `data` TEXT NOT NULL
, `updated` DATETIME NOT NULL
, `interval_seconds` INTEGER NOT NULL DEFAULT 60
, `version` INTEGER NOT NULL DEFAULT 0
, `uid` TEXT NOT NULL DEFAULT 0
, `namespace_uid` TEXT NOT NULL
, `rule_group` TEXT NOT NULL
, `no_data_state` TEXT NOT NULL DEFAULT 'NoData'
, `exec_err_state` TEXT NOT NULL DEFAULT 'Alerting'
, `for` INTEGER NOT NULL DEFAULT 0, `annotations` TEXT NULL, `labels` TEXT NULL, `dashboard_uid` TEXT NULL, `panel_id` INTEGER NULL, `rule_group_idx` INTEGER NOT NULL DEFAULT 1, `is_paused` INTEGER NOT NULL DEFAULT 0);
CREATE UNIQUE INDEX `UQE_alert_rule_org_id_uid` ON `alert_rule` (`org_id`,`uid`);
CREATE INDEX `IDX_alert_rule_org_id_namespace_uid_rule_group` ON `alert_rule` (`org_id`,`namespace_uid`,`rule_group`);
CREATE UNIQUE INDEX `UQE_alert_rule_org_id_namespace_uid_title` ON `alert_rule` (`org_id`,`namespace_uid`,`title`);
CREATE INDEX `IDX_alert_rule_org_id_dashboard_uid_panel_id` ON `alert_rule` (`org_id`,`dashboard_uid`,`panel_id`);
sqlite> .schema alert_rule_version 
CREATE TABLE `alert_rule_version` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `rule_org_id` INTEGER NOT NULL
, `rule_uid` TEXT NOT NULL DEFAULT 0
, `rule_namespace_uid` TEXT NOT NULL
, `rule_group` TEXT NOT NULL
, `parent_version` INTEGER NOT NULL
, `restored_from` INTEGER NOT NULL
, `version` INTEGER NOT NULL
, `created` DATETIME NOT NULL
, `title` TEXT NOT NULL
, `condition` TEXT NOT NULL
, `data` TEXT NOT NULL
, `interval_seconds` INTEGER NOT NULL
, `no_data_state` TEXT NOT NULL DEFAULT 'NoData'
, `exec_err_state` TEXT NOT NULL DEFAULT 'Alerting'
, `for` INTEGER NOT NULL DEFAULT 0, `annotations` TEXT NULL, `labels` TEXT NULL, `rule_group_idx` INTEGER NOT NULL DEFAULT 1, `is_paused` INTEGER NOT NULL DEFAULT 0);
CREATE UNIQUE INDEX `UQE_alert_rule_version_rule_org_id_rule_uid_version` ON `alert_rule_version` (`rule_org_id`,`rule_uid`,`version`);
CREATE INDEX `IDX_alert_rule_version_rule_org_id_rule_namespace_uid_rule_group` ON `alert_rule_version` (`rule_org_id`,`rule_namespace_uid`,`rule_group`);
```


In postgres they are boolean:
```
grafana=> \d+ alert_rule
                                                                      Table "public.alert_rule"
      Column      |            Type             | Collation | Nullable |                Default                 | Storage  | Compression | Stats target | Description 
------------------+-----------------------------+-----------+----------+----------------------------------------+----------+-------------+--------------+-------------
 id               | integer                     |           | not null | nextval('alert_rule_id_seq'::regclass) | plain    |             |              | 
 org_id           | bigint                      |           | not null |                                        | plain    |             |              | 
 title            | character varying(190)      |           | not null |                                        | extended |             |              | 
 condition        | character varying(190)      |           | not null |                                        | extended |             |              | 
 data             | text                        |           | not null |                                        | extended |             |              | 
 updated          | timestamp without time zone |           | not null |                                        | plain    |             |              | 
 interval_seconds | bigint                      |           | not null | 60                                     | plain    |             |              | 
 version          | integer                     |           | not null | 0                                      | plain    |             |              | 
 uid              | character varying(40)       |           | not null | 0                                      | extended |             |              | 
 namespace_uid    | character varying(40)       |           | not null |                                        | extended |             |              | 
 rule_group       | character varying(190)      |           | not null |                                        | extended |             |              | 
 no_data_state    | character varying(15)       |           | not null | 'NoData'::character varying            | extended |             |              | 
 exec_err_state   | character varying(15)       |           | not null | 'Alerting'::character varying          | extended |             |              | 
 for              | bigint                      |           | not null | 0                                      | plain    |             |              | 
 annotations      | text                        |           |          |                                        | extended |             |              | 
 labels           | text                        |           |          |                                        | extended |             |              | 
 dashboard_uid    | character varying(40)       |           |          |                                        | extended |             |              | 
 panel_id         | bigint                      |           |          |                                        | plain    |             |              | 
 rule_group_idx   | integer                     |           | not null | 1                                      | plain    |             |              | 
 is_paused        | boolean                     |           | not null | false                                  | plain    |             |              | 
Indexes:
    "alert_rule_pkey" PRIMARY KEY, btree (id)
    "IDX_alert_rule_org_id_dashboard_uid_panel_id" btree (org_id, dashboard_uid, panel_id)
    "IDX_alert_rule_org_id_namespace_uid_rule_group" btree (org_id, namespace_uid, rule_group)
    "UQE_alert_rule_org_id_namespace_uid_title" UNIQUE, btree (org_id, namespace_uid, title)
    "UQE_alert_rule_org_id_uid" UNIQUE, btree (org_id, uid)
Access method: heap

grafana=> \d+ alert_rule_version
                                                                       Table "public.alert_rule_version"
       Column       |            Type             | Collation | Nullable |                    Default                     | Storage  | Compression | Stats target | Description 
--------------------+-----------------------------+-----------+----------+------------------------------------------------+----------+-------------+--------------+-------------
 id                 | integer                     |           | not null | nextval('alert_rule_version_id_seq'::regclass) | plain    |             |              | 
 rule_org_id        | bigint                      |           | not null |                                                | plain    |             |              | 
 rule_uid           | character varying(40)       |           | not null | 0                                              | extended |             |              | 
 rule_namespace_uid | character varying(40)       |           | not null |                                                | extended |             |              | 
 rule_group         | character varying(190)      |           | not null |                                                | extended |             |              | 
 parent_version     | integer                     |           | not null |                                                | plain    |             |              | 
 restored_from      | integer                     |           | not null |                                                | plain    |             |              | 
 version            | integer                     |           | not null |                                                | plain    |             |              | 
 created            | timestamp without time zone |           | not null |                                                | plain    |             |              | 
 title              | character varying(190)      |           | not null |                                                | extended |             |              | 
 condition          | character varying(190)      |           | not null |                                                | extended |             |              | 
 data               | text                        |           | not null |                                                | extended |             |              | 
 interval_seconds   | bigint                      |           | not null |                                                | plain    |             |              | 
 no_data_state      | character varying(15)       |           | not null | 'NoData'::character varying                    | extended |             |              | 
 exec_err_state     | character varying(15)       |           | not null | 'Alerting'::character varying                  | extended |             |              | 
 for                | bigint                      |           | not null | 0                                              | plain    |             |              | 
 annotations        | text                        |           |          |                                                | extended |             |              | 
 labels             | text                        |           |          |                                                | extended |             |              | 
 rule_group_idx     | integer                     |           | not null | 1                                              | plain    |             |              | 
 is_paused          | boolean                     |           | not null | false                                          | plain    |             |              | 
Indexes:
    "alert_rule_version_pkey" PRIMARY KEY, btree (id)
    "IDX_alert_rule_version_rule_org_id_rule_namespace_uid_rule_grou" btree (rule_org_id, rule_namespace_uid, rule_group)
    "UQE_alert_rule_version_rule_org_id_rule_uid_version" UNIQUE, btree (rule_org_id, rule_uid, version)
Access method: heap

grafana=> \d+ alert_configuration_history
                                                                        Table "public.alert_configuration_history"
           Column           |         Type          | Collation | Nullable |                         Default                         | Storage  | Compression | Stats target | Description 
----------------------------+-----------------------+-----------+----------+---------------------------------------------------------+----------+-------------+--------------+-------------
 id                         | integer               |           | not null | nextval('alert_configuration_history_id_seq'::regclass) | plain    |             |              | 
 org_id                     | bigint                |           | not null | 0                                                       | plain    |             |              | 
 alertmanager_configuration | text                  |           | not null |                                                         | extended |             |              | 
 configuration_hash         | character varying(32) |           | not null | 'not-yet-calculated'::character varying                 | extended |             |              | 
 configuration_version      | character varying(3)  |           | not null |                                                         | extended |             |              | 
 created_at                 | integer               |           | not null |                                                         | plain    |             |              | 
 default                    | boolean               |           | not null | false                                                   | plain    |             |              | 
Indexes:
    "alert_configuration_history_pkey" PRIMARY KEY, btree (id)
Access method: heap

```
