### PR TITLE
Transform char(13) to chr(13)

### DIFF
--- a/cmd/grafana-migrate/main.go
+++ b/cmd/grafana-migrate/main.go
@@ -69,7 +69,10 @@ func main() {
 	log.Infoln("✅ migration_log statements removed")
 	// Fix char conversion (char -> chr)
 	if err := sqlite.CustomSanitize(dumpPath, `char\(10\)\)`, []byte("chr(10))")); err != nil {
-		log.Fatalf("❌ %v - failed to perform char keyword sanitizing of the dump file.", err)
+		log.Fatalf("❌ %v - failed to perform char (LF) keyword sanitizing of the dump file.", err)
+	}
+	if err := sqlite.CustomSanitize(dumpPath, `char\(13\)\)`, []byte("chr(13))")); err != nil {
+		log.Fatalf("❌ %v - failed to perform char (CR) keyword sanitizing of the dump file.", err)
 	}
 	log.Infoln("✅ char keyword transformed")
 


### PR DESCRIPTION
# Summary

There is a transformation of SQLite char() for line feed, but not for carriage return, which causes some issues where CR is present in some strings, especially when Grafana alerts store execution errors where the return included CR.

## Rationale

This would be the simplest way (albeit with quite a lot of copy-paste) to address what I came across at work, but I suspect the regex could be better.

I noticed that this came up in the context of the `replace()` function, which in this case was coming up as `replace('string', char(), char())`, so it _might_ be more precise to instead look for the regex `,char\((\d+)\)\)` although this would then have to handle re-substituting the catchment group `$1` which was `(\d+)` back into the byte array.